### PR TITLE
Refactor the package publishing setup

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -80,10 +80,9 @@ jobs:
         path: .tox/**/log/
 
   publish:
-    name: Publish to PyPI registry
+    name: Publish to PyPI-ish registries
     needs:
     - tests
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
 
     env:
@@ -100,10 +99,23 @@ jobs:
         tox
     - name: Check out src from Git
       uses: actions/checkout@v2
-    - name: Get history and tags for SCM versioning to work
-      run: |
-        git fetch --prune --unshallow
-        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      with:
+        fetch-depth: >-
+          ${{
+              (
+                github.event_name == 'create' &&
+                github.event.ref_type == 'tag'
+              ) && 1 || 0
+          }}
+    - name: Drop Git tags from HEAD for non-tag-create events
+      if: >-
+        github.event_name != 'create' ||
+        github.event.ref_type != 'tag'
+      run: >-
+        git tag --points-at HEAD
+        |
+        xargs git tag --delete
+      shell: bash
     - name: Instruct setuptools-scm not to add a local version part
       if: >-
         github.event_name == 'push' &&
@@ -119,9 +131,14 @@ jobs:
       run: python -m tox -p auto --parallel-live -vvvv
     - name: Publish to test.pypi.org
       if: >-
-        github.event_name == 'push' &&
-        github.ref == format(
-          'refs/heads/{0}', github.event.repository.default_branch
+        (
+          github.event_name == 'push' &&
+          github.ref == format(
+            'refs/heads/{0}', github.event.repository.default_branch
+          )
+        ) || (
+          github.event_name == 'create' &&
+          github.event.ref_type == 'tag'
         )
       uses: pypa/gh-action-pypi-publish@master
       with:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,14 +4,18 @@ on:
   push:
     branches:
     - master
+    tags-ignore:
+    - >-
+      **
   pull_request:
     branches:
     - master
-  create:
-    branches:
-    - master
-    tags:
+  create:  # is used for publishing to PyPI and TestPyPI
+    tags:  # any tag regardless of its name, no branches
     - "[0-9]+.[0-9]+.*"
+    branches-ignore:
+    - >-
+      **
   schedule:
   # Run every Friday at 18:02 UTC
   # https://crontab.guru/#2_18_*_*_5

--- a/tox.ini
+++ b/tox.ini
@@ -52,10 +52,8 @@ description =
     PYPI could fail
 # `usedevelop = true` overrides `skip_install` instruction, it's unwanted
 usedevelop = false
-# don't install molecule itself in this env
 skip_install = true
 deps =
-    collective.checkdocs == 0.2
     pep517 >= 0.5.0
     twine==1.14.0  # pyup: ignore
 setenv =


### PR DESCRIPTION
* Set up GHA triggers and version generation to avoid race conditions
* Drop unnecessary wrappers from tox.ini
* Run package build & metadata checks on PRs too