### PR TITLE
Remove CSS that lives in the antsibull Sphinx extension

### DIFF
--- a/sphinx_ansible_theme/static/css/ansible.css
+++ b/sphinx_ansible_theme/static/css/ansible.css
@@ -451,6 +451,8 @@ h6 {
     }
 }
 /* ansibleOptionLink is adapted from h1 .headerlink in sphinx_rtd_theme */
+/* This definition lives in the antsibull Sphinx extension; we update it here to use the icon from FontAwesome */
+/* https://github.com/ansible-community/antsibull/blob/main/sphinx_antsibull_ext/css/antsibull-minimal.scss */
 tr .ansibleOptionLink::after {
     content: "" !important;
     font-family: FontAwesome;

--- a/sphinx_ansible_theme/static/css/ansible.css
+++ b/sphinx_ansible_theme/static/css/ansible.css
@@ -191,12 +191,6 @@ table {
     display: block;
     max-width: 100%;
 }
-.documentation-table td.elbow-placeholder {
-    border-left: 1px solid #000;
-    border-top: 0;
-    width: 30px;
-    min-width: 30px;
-}
 .documentation-table td,
 .documentation-table th {
     padding: 4px;
@@ -457,16 +451,11 @@ h6 {
     }
 }
 /* ansibleOptionLink is adapted from h1 .headerlink in sphinx_rtd_theme */
-tr:hover .ansibleOptionLink::after {
-    visibility: visible;
-}
 tr .ansibleOptionLink::after {
-    content: "";
+    content: "" !important;
     font-family: FontAwesome;
 }
 tr .ansibleOptionLink {
-    visibility: hidden;
-    display: inline-block;
     font: normal normal normal 14px/1 FontAwesome;
     text-rendering: auto;
     -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
This part of the CSS is used only for the options/return value tables in plugin docs. The definitions for `ansibleOptionLink` are still partially here since the definitions in antsibull do not use FontAwesome, which is not present in every theme (but is used in this theme).

I'm not 100% happy with this split. This one will survive a reformatting of the plugin docs, so it would also be ok to completely keep it here (while having some parts of it repeated in the antsibull docs). @webknjaz what do you think?