### PR TITLE
make dl text closer to the previous dt

### DIFF
--- a/sphinx_ansible_theme/static/css/ansible.css
+++ b/sphinx_ansible_theme/static/css/ansible.css
@@ -484,3 +484,5 @@ tr .ansibleOptionLink {
 .rst-content div[class^="highlight"] pre {
     white-space: pre-wrap;
 }
+
+.rst-content dl dt { margin-bottom: 0; }


### PR DESCRIPTION
fix the text in `<dl>` being equally spaced between the previous and the
following `<dt>` and rather bring it close to the previous `<dt>`.

Before
![before_playbook](https://user-images.githubusercontent.com/8579/127735334-ba46e665-042e-40d2-b362-a5c8b04f97a4.png)

After
![after_playbook](https://user-images.githubusercontent.com/8579/127735366-307e72f7-220b-4029-b9ac-e7fc463d351d.png)

This will do the same effect in the see-also section of modules.

To review carefully because my CSS fu is near zero