### PR TITLE
implement borderless option table in module page

### DIFF
--- a/sphinx_ansible_theme/static/css/ansible.css
+++ b/sphinx_ansible_theme/static/css/ansible.css
@@ -191,16 +191,16 @@ table {
     display: block;
     max-width: 100%;
 }
-.documentation-table td,
-.documentation-table th {
-    padding: 4px;
-    border-left: 1px solid #000;
-    border-top: 1px solid #000;
-}
+
 .documentation-table {
-    border-right: 1px solid #000;
-    border-bottom: 1px solid #000;
+    border: 0px;
 }
+
+.rst-content table,td,tr,th { border:0; }
+.rst-content th { background-color: #6AB0DE; }
+.rst-content tr:nth-child(even) { background: #E7F2FA; }
+.rst-content tr:nth-child(odd) { background: #FFF; }
+
 @media print {
     * {
         background: 0 0 !important;


### PR DESCRIPTION
I find it more beautiful and it matches the note in the page 

requires also https://github.com/ansible-community/antsibull/pull/296
I was not able to build the repo so needs extra care for review
![ansible-table](https://user-images.githubusercontent.com/8579/127778727-5d97150b-8aa9-470d-9e92-ecebc0b6994b.png)
