### PR TITLE
Do not set 'display: block' on all <table>s

### DIFF
--- a/sphinx_ansible_theme/static/css/ansible.css
+++ b/sphinx_ansible_theme/static/css/ansible.css
@@ -188,7 +188,6 @@ th {
 }
 table {
     overflow-x: auto;
-    display: block;
     max-width: 100%;
 }
 .documentation-table td,


### PR DESCRIPTION
Currently the theme's CSS sets `display: block` for **all** `<table>` elements. There are multiple reasons why not to do it (see for example https://stackoverflow.com/a/7456216), and doing that breaks other uses, like https://github.com/ansible-community/antsibull/pull/354#issuecomment-989201744. So please let's remove that faulty line :)

(That line was originally added to the theme in https://github.com/ansible/ansible/commit/373b1dcf5961f57702e9070bcedf6577bda996f4#diff-9a54ec88f2695401d17b8ea9a48d9970c13279b8c01dc902367d00c70c4e31e2R420 and has been carried around ever since then. I have no idea what the original intention was, but I don't think it ever did anything good.)