### PR TITLE
Lynx / screen reader improvements

### DIFF
--- a/sphinx_ansible_theme/searchbox.html
+++ b/sphinx_ansible_theme/searchbox.html
@@ -4,7 +4,8 @@
 {%- if 'singlehtml' not in builder %}
 <div role="search">
   <form id="rtd-search-form" class="wy-form"{% if not theme_swift_id %} action="{{ pathto('search') }}"{% endif %} method="get">
-    <input type="text" aria-label="Search docs:" class="st-default-search-input" name="q" placeholder="{{ _('Search docs') }}" />
+    <label class="sr-only" for="q">Search docs:</label>
+    <input type="text" class="st-default-search-input" id="q" name="q" placeholder="{{ _('Search docs') }}" />
     <input type="hidden" name="check_keywords" value="yes" />
     <input type="hidden" name="area" value="default" />
   </form>

--- a/sphinx_ansible_theme/searchbox.html
+++ b/sphinx_ansible_theme/searchbox.html
@@ -4,7 +4,7 @@
 {%- if 'singlehtml' not in builder %}
 <div role="search">
   <form id="rtd-search-form" class="wy-form"{% if not theme_swift_id %} action="{{ pathto('search') }}"{% endif %} method="get">
-    <input type="text" class="st-default-search-input" name="q" placeholder="{{ _('Search docs') }}" />
+    <input type="text" aria-label="Search docs:" class="st-default-search-input" name="q" placeholder="{{ _('Search docs') }}" />
     <input type="hidden" name="check_keywords" value="yes" />
     <input type="hidden" name="area" value="default" />
   </form>

--- a/sphinx_ansible_theme/version_chooser.html
+++ b/sphinx_ansible_theme/version_chooser.html
@@ -13,6 +13,7 @@
           window.location.replace(new_version_url);
         }
       </script>
+      <label class="sr-only" for="version-list">Select version:</label>
       <select
           class="version-list"
           id="version-list"

--- a/sphinx_ansible_theme/version_chooser.html
+++ b/sphinx_ansible_theme/version_chooser.html
@@ -2,7 +2,7 @@
 {# Creates dropdown version selection in the top-left navigation. #}
 <div class="version">
   {% if available_versions is defined %}
-    <div class="version-dropdown">
+    <form class="version-dropdown" method="get">
       <script>
         function switchVersionTo(slug) {
           var current_url_path = window.location.pathname;
@@ -27,7 +27,7 @@
         </option>
         {% endfor %}
       </select>
-    </div>
+    </form>
   {% else %}
     {{ nav_version }}
   {% endif %}


### PR DESCRIPTION
* Embed `<select>` into `<form>` for Lynx. Please note that this does not make the form work on Lynx. Lynx does not support JavaScript, and the form won't work without JavaScript. Fixes #47.
* Use `sr-only` `<label>` for the search input box. Right now on text-based browsers and screen readers, there will just be an input box without any further indication on what it should be.

Please note that both with Lynx and Links (text mode), neither version selector nor search box actually work due to no JavaScript support in these browsers. No idea whether screen readers support this.