### PR TITLE
bump gha actions/checkout to v3

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,7 +37,8 @@ jobs:
           - TOXENV: linters
           - TOXENV: packaging
     steps:
-      - uses: actions/checkout@master
+      - name: Check out src from Git
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -100,7 +101,8 @@ jobs:
       TOXENV: docs
 
     steps:
-      - uses: actions/checkout@master
+      - name: Check out src from Git
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -168,7 +170,7 @@ jobs:
           --user
           tox
       - name: Check out src from Git
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: >-
             ${{


### PR DESCRIPTION
- v3.0.0 (https://github.com/actions/checkout/releases/tag/v3.0.0) was
released on March 1st 2022.
- the project switched from `master` to `main` as the default branch

PR #55 should be merged first to at least fix the linting.