### PR TITLE
Make environment variable links blue

### DIFF
--- a/src/sphinx_ansible_theme/static/css/ansible.css
+++ b/src/sphinx_ansible_theme/static/css/ansible.css
@@ -485,3 +485,6 @@ tr .ansibleOptionLink {
 }
 
 .rst-content dl dt { margin-bottom: 0; }
+
+/*! Make sure that environment variable links are blue */
+.rst-content code.xref.std-envvar { color: #2980b9; }


### PR DESCRIPTION
Fixes #73. Example (showing both a regular link and an environment variable link):

![Example](https://user-images.githubusercontent.com/5781356/205482271-70b0f00a-c396-46f6-94c3-23cc1047145b.png)
